### PR TITLE
Added the pandith section in the Home page

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -6,28 +6,29 @@ import Testimonials from "./Testimonials";
 import ContactUs from "./ContactUs";
 import Footer from "./Footer";
 import AboutUs from "./AboutUs";
+import Pandiths from "./Pandiths";
 
 function MainLayout() {
-    const [activeSection, setActiveSection] = useState("home");
+  const [activeSection, setActiveSection] = useState("home");
 
-    useEffect(() => {
-        const sections = ["home", "services", "about", "testimonials", "contact"];
-        const handleScroll = () => {
-          sections.forEach((id) => {
-            const element = document.getElementById(id);
-            if (element) {
-              const { top, bottom } = element.getBoundingClientRect();
-              if (top < window.innerHeight / 2 && bottom > window.innerHeight / 2) {
-                setActiveSection(id);
-              }
-            }
-          });
-        };
-    
-        window.addEventListener("scroll", handleScroll);
-        return () => window.removeEventListener("scroll", handleScroll);
-      }, []);
-    
+  useEffect(() => {
+    const sections = ["home", "services", "about", "testimonials", "contact"];
+    const handleScroll = () => {
+      sections.forEach((id) => {
+        const element = document.getElementById(id);
+        if (element) {
+          const { top, bottom } = element.getBoundingClientRect();
+          if (top < window.innerHeight / 2 && bottom > window.innerHeight / 2) {
+            setActiveSection(id);
+          }
+        }
+      });
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
   return (
     <div className="relative flex flex-col min-h-screen">
       <Navbar activeSection={activeSection} />
@@ -39,8 +40,11 @@ function MainLayout() {
         <Services />
       </section>
 
-      <section id="about" >
+      <section id="about">
         <AboutUs />
+      </section>
+      <section id="pandiths">
+        <Pandiths />
       </section>
 
       <section id="testimonials">

--- a/src/components/Pandiths.tsx
+++ b/src/components/Pandiths.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../firebase"; // Adjust path if needed
+
+interface Pandith {
+  id: string;
+  pandith_name: string;
+  pandith_description: string;
+  experience: string;
+  spoken: string[];
+  expertise: string;
+  photo: string;
+}
+
+function Pandiths() {
+  const [pandiths, setPandiths] = useState<Pandith[]>([]);
+  const [showDetails, setShowDetails] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchPandiths = async () => {
+      const snapshot = await getDocs(collection(db, "pandiths"));
+      const pandithList: Pandith[] = snapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...(doc.data() as Omit<Pandith, "id">),
+      }));
+      //   console.log(` pandithList`, JSON.stringify(pandithList));
+      setPandiths(pandithList);
+    };
+    fetchPandiths();
+  }, []);
+
+  return (
+    <section id="pandiths" className="py-16 bg-[#13142e]">
+      <div className="max-w-screen-xl mx-auto px-6 lg:px-16">
+        <h2 className="text-4xl font-semibold text-center text-primary-voilet mb-12">
+          Available Pandiths
+        </h2>
+        {pandiths.length === 0 ? (
+          <p className="text-white text-center">Loading...</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
+            {pandiths.map((pandith, index) => (
+              <div
+                key={pandith.id}
+                className="bg-gradient-to-b from-[#252376] to-[#13142e] p-6 rounded-2xl shadow-xl border border-[#252376] text-white relative"
+              >
+                <img
+                  src={pandith.photo || "https://via.placeholder.com/100"}
+                  alt={pandith.pandith_name}
+                  className="w-20 h-20 rounded-full mx-auto mb-4 border-2 border-primary-voilet object-cover"
+                />
+                <h3 className="text-2xl font-semibold text-center text-primary-voilet mb-2">
+                  {pandith.pandith_name}
+                </h3>
+                <p className="text-gray-300 text-center mb-2">
+                  <strong>Expertise:</strong> {pandith.expertise}
+                </p>
+                <p className="text-gray-300 text-center mb-2">
+                  <strong>Experience:</strong> {pandith.experience}
+                </p>
+                <p className="text-gray-300 text-center mb-4">
+                  <strong>Languages:</strong> {pandith.spoken.join(", ")}
+                </p>
+                <button
+                  className="bg-primary-voilet text-white px-4 py-2 rounded-lg hover:bg-opacity-80 transition w-full"
+                  onClick={() =>
+                    setShowDetails(showDetails === index ? null : index)
+                  }
+                >
+                  {showDetails === index ? "View Less" : "View More"}
+                </button>
+
+                {showDetails === index && (
+                  <p className="text-gray-300 text-center mt-4">
+                    {pandith.pandith_description}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default Pandiths;

--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -170,6 +170,7 @@ export const allServices = [
   "Home",
   "Services",
   "About",
+  "Pandiths",
   "Testimonials",
   "Contact",
 ];


### PR DESCRIPTION
## Summary by Sourcery

Add a new Pandiths section to the home page that retrieves pandith data from Firestore and displays profile cards with expandable details. Update the main layout and configuration to include the new section in navigation and scroll tracking.

New Features:
- Introduce Pandiths component to fetch and present pandith profiles with expandable descriptions
- Integrate the Pandiths section into MainLayout to display on the home page

Enhancements:
- Add 'Pandiths' to the list of sections in the site configuration for navigation and active-section tracking